### PR TITLE
Add ability to log responses

### DIFF
--- a/lib/concise_logging.rb
+++ b/lib/concise_logging.rb
@@ -1,4 +1,25 @@
 require "concise_logging/version"
 require "concise_logging/log_middleware"
 require "concise_logging/log_subscriber"
+require "concise_logging/configuration"
 require "concise_logging/railtie" if defined? Rails
+
+module ConciseLogging
+  class << self
+    # Call this method to modify defaults in your initializers.
+    #
+    # @example
+    #   ConciseLogging.configure do |config|
+    #     config.log_response = true
+    #   end
+    def configure
+      yield(configuration)
+    end
+
+    # The configuration object.
+    # @see ConciseLogging.configure
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
+end

--- a/lib/concise_logging/configuration.rb
+++ b/lib/concise_logging/configuration.rb
@@ -1,0 +1,9 @@
+module ConciseLogging
+  class Configuration
+    attr_accessor :log_response
+
+    def initializer
+      @log_response = false
+    end
+  end
+end

--- a/lib/concise_logging/controller_runtime.rb
+++ b/lib/concise_logging/controller_runtime.rb
@@ -1,0 +1,11 @@
+module ConciseLogging
+  module ControllerRuntime
+    extend ActiveSupport::Concern
+
+    def append_info_to_payload(payload)
+      super
+      payload[:response_body] = response.body
+    end
+
+  end
+end

--- a/lib/concise_logging/controller_runtime.rb
+++ b/lib/concise_logging/controller_runtime.rb
@@ -4,7 +4,7 @@ module ConciseLogging
 
     def append_info_to_payload(payload)
       super
-      payload[:response_body] = response.body
+      payload[:response_body] = response.body if response.content_type =~ /^application\/json/
     end
 
   end

--- a/lib/concise_logging/log_subscriber.rb
+++ b/lib/concise_logging/log_subscriber.rb
@@ -26,7 +26,7 @@ module ConciseLogging
         ip: format("%-15s", ip),
         method: format_method(format("%-6s", method)),
         status: format_status(status),
-        path: path
+        path: color(path, BOLD)
       )
       message << " redirect_to=#{location}" if location.present?
       message << " parameters=#{params}" if params.present?

--- a/lib/concise_logging/log_subscriber.rb
+++ b/lib/concise_logging/log_subscriber.rb
@@ -32,6 +32,7 @@ module ConciseLogging
       message << " parameters=#{params}" if params.present?
       message << " #{color(exception_details, RED)}" if exception_details.present?
       message << " (app:#{app}ms db:#{db}ms)"
+      message << " #{payload[:response_body].inspect}" if payload[:response_body].present?
 
       logger.warn message
     end

--- a/lib/concise_logging/railtie.rb
+++ b/lib/concise_logging/railtie.rb
@@ -6,6 +6,16 @@ module ConciseLogging
       end
 
       ConciseLogging::LogSubscriber.attach_to :action_controller
+
+      config.after_initialize do
+        ActiveSupport.on_load(:action_controller) do
+          # Lazily load action_controller methods
+          #
+          require 'concise_logging/controller_runtime'
+
+          include ConciseLogging::ControllerRuntime if ConciseLogging.configuration.log_response
+        end
+      end
     end
   end
 end

--- a/lib/concise_logging/version.rb
+++ b/lib/concise_logging/version.rb
@@ -1,3 +1,3 @@
 module ConciseLogging
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/lib/concise_logging/version.rb
+++ b/lib/concise_logging/version.rb
@@ -1,3 +1,3 @@
 module ConciseLogging
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Hi guys,

I did this addition to concise logging as I am running an API and would like responses logged in the same line. It is turned off by default and can be turned on by adding a gem initializer

This PR also adds configuration ability